### PR TITLE
handling of SequelizeUniqueConstraintError fix-#133

### DIFF
--- a/server/app/services/barman-service.js
+++ b/server/app/services/barman-service.js
@@ -37,9 +37,15 @@ async function createBarman(newBarman, _embedded) {
         // Remove critic fields
         co.password = undefined;
     } catch (err) {
-        logger.warn('Barman service: Error while creating barman', err);
-        await transaction.rollback();
-        throw createServerError('ServerError', 'Error while creating barman');
+        if (err.Errors === sequelize.SequelizeUniqueConstraintError) {
+            logger.warn('Barman service: Error while creating barman username not unique', err);
+            await transaction.rollback();
+            throw createUserError('BadUsername', 'a username must be unique');
+        } else {
+            logger.warn('Barman service: Error while creating barman', err);
+            await transaction.rollback();
+            throw createServerError('ServerError', 'Error while creating barman');
+        }
     }
 
     // Associations
@@ -164,9 +170,15 @@ async function updateBarmanById(barmanId, updatedBarman, _embedded) {
             }
         }
     } catch (err) {
-        logger.warn('Barman service: Error while updating barman', err);
-        await transaction.rollback();
-        throw createServerError('ServerError', 'Error while updating barman');
+        if (err.Errors === sequelize.SequelizeUniqueConstraintError) {
+            logger.warn('Barman service: Error while updating barman', err);
+            await transaction.rollback();
+            throw createUserError('BadUsername', 'a username must be unique');
+        } else {
+            logger.warn('Barman service: Error while updating barman', err);
+            await transaction.rollback();
+            throw createServerError('ServerError', 'Error while updating barman');
+        }
     }
 
     // Associations

--- a/server/app/services/special-account-service.js
+++ b/server/app/services/special-account-service.js
@@ -50,9 +50,15 @@ async function createSpecialAccount(newSpecialAccount, _embedded) {
         co.password = undefined;
 
     } catch (err) {
-        logger.verbose('SpecialAccount service: Error while creating specialAccount %o', err);
-        await transaction.rollback();
-        throw createServerError('ServerError', 'Error while creating a specialAccount');
+        if (err.Errors === sequelize.SequelizeUniqueConstraintError) {
+            logger.warn('SpecialAccount service: Error while creating special account', err);
+            await transaction.rollback();
+            throw createUserError('BadUsername', 'a username must be unique');
+        } else {
+            logger.warn('SpecialAccount service: Error while creating special account', err);
+            await transaction.rollback();
+            throw createServerError('ServerError', 'Error while creating special account');
+        }
     }
 
     if (_embedded) {
@@ -141,9 +147,15 @@ async function updateSpecialAccountById(specialAccountId, updatedSpecialAccount,
             );
         }
     } catch (err) {
-        logger.warn('SpecialAccount service: Error while updating SpecialAccount', err);
-        await transaction.rollback();
-        throw createServerError('ServerError', 'Error while updating SpecialAccount');
+        if (err.Errors === sequelize.SequelizeUniqueConstraintError) {
+            logger.warn('SpecialAccount service: Error while updating special account', err);
+            await transaction.rollback();
+            throw createUserError('BadUsername', 'a username must be unique');
+        } else {
+            logger.warn('SpecialAccount service: Error while updating special account', err);
+            await transaction.rollback();
+            throw createServerError('ServerError', 'Error while updating special account');
+        }
     }
 
     if (_embedded) {


### PR DESCRIPTION
fix #133 
I add a "if()" in the errors catch of barmen-create, barmen-update, specialAccount-create and specialAccount-update to handle the specific case of a SequelizeUniqueConstraintError. It's now returning a code Error 400 instead of a Error 500. Tested with PostMan